### PR TITLE
changes for timeline-history.json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+GPX_Output/
+location-history.json
+Timeline.json

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ I created this because I needed an easy way to find time stamps from the last ye
 
 To do this, on your Android device go to **settings > Location > Timeline > Export Timeline data**.  
 
-2. Place the exported Timeline.json file into the same folder as Timeline-GPX-Exporter.py
+2. Place the exported Timeline.json file into the same folder as Timeline-GPX-Exporter.py. 
+   * If this process instead produces a location-history.json file thats OK, the script will automatically detect and parse this format as well. Do not rename the file. 
 
 3. Run Timeline-GPX-Exporter.py script. Daily GPX logs with be generated in ./GPX_Output with the format YYYY-MM-DD.gpx. 
 

--- a/Timeline-GPX-Exporter.py
+++ b/Timeline-GPX-Exporter.py
@@ -2,7 +2,8 @@ import os
 import json
 import xml.etree.ElementTree as ET
 import xml.dom.minidom
-from datetime import datetime
+from datetime import datetime, timedelta
+from dateutil import parser
 
 def create_gpx_file(points, output_file):
     gpx = ET.Element("gpx", version="1.1", creator="https://github.com/Makeshit/Timeline-GPX-Exporter")
@@ -48,19 +49,62 @@ def parse_json(input_file):
 
     return points_by_date
 
+def parse_json2(input_file):
+    with open(input_file, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    points_by_date = {}
+
+    # Extract data points
+    # segments are now in the top level of the JSON file in an array, no need to index into "semanticSegments"
+    for segment in data:
+        # path points are now defined using 'geo:lat,lon' format
+        # and the time is an offset in minutes from the segment start time
+        start_time = parser.parse(segment.get('startTime'))
+        for path_point in segment.get("timelinePath", []):
+            try:
+                # Extract and parse data
+                raw_coords = path_point["point"].replace("°", "").replace("geo:", "").strip()
+                coords = raw_coords.split(",")
+                lat, lon = float(coords[0]), float(coords[1])
+                time = start_time + timedelta(minutes=float(path_point["durationMinutesOffsetFromStartTime"]))
+
+                # Extract date for grouping
+                date = time.date().isoformat()
+
+                # Group by date
+                if date not in points_by_date:
+                    points_by_date[date] = []
+                points_by_date[date].append({"lat": lat, "lon": lon, "time": time.isoformat()})
+            except (KeyError, ValueError):
+                continue  # Skip invalid points
+
+    return points_by_date
+
 def main():
     script_dir = os.getcwd()  # Directory where the script is being run
+    
     input_file = os.path.join(script_dir, "Timeline.json")  # Input JSON file
+    input_file2 = os.path.join(script_dir, "location-history.json")  # Input JSON file for alternate format
+    
     output_dir = os.path.join(script_dir, "GPX_Output")  # Directory for output GPX files
 
     # Ensure the output directory exists
     os.makedirs(output_dir, exist_ok=True)
 
+    file = '1'
     if not os.path.exists(input_file):
-        print(f"Input file 'Timeline.json' not found in {script_dir}.")
+        print(f"Input file 'Timeline.json' not found in {script_dir}, trying 'location-history.json'.")
+        file = '2'
+    if not os.path.exists(input_file2):
+        print(f"Input file 'location-history.json' not found in {script_dir}. Exiting...")
+        file = '-1'
         return
 
-    points_by_date = parse_json(input_file)
+    if file == '1':
+        points_by_date = parse_json(input_file)
+    elif file == '2':
+        points_by_date = parse_json2(input_file2)
 
     for date, points in points_by_date.items():
         # Convert date format to dd-mm-yyyy


### PR DESCRIPTION
the procedure indicated in the readme now produces a differently formatted file called 'location-history.json'. This file has entries as the top level array, and treats path_points as time offsets from the segment start time. 

I have added a parse_json2 method that will produce the same output as parse_json, and main will automatically call this method if it finds a location-history.json file instead of Timeline.json.

